### PR TITLE
Return non-stringified JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
         "@types/google-protobuf": "^3.15.6",
         "@types/minimist": "^1.2.2",
         "@types/node": "^17.0.29",
+        "@types/json-bigint": "^1.0.1",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
         "eslint": "^7.29.0",
@@ -41,9 +43,9 @@
     "dependencies": {
         "@concordium/node-sdk": "^0.7.2",
         "@grpc/grpc-js": "^1.6.7",
-        "@types/uuid": "^8.3.4",
         "express": "^4.18.0",
         "jayson": "^3.6.6",
+        "json-bigint": "^1.0.0",
         "minimist": "^1.2.6",
         "uuid": "^8.3.2",
         "winston": "^3.7.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,13 @@ import NodeClient from './client';
 import getJsonRpcMethods from './methods';
 import logger from './logger';
 import { v4 as uuidv4 } from 'uuid';
+import JSONbig from 'json-bigint';
+
+// DANGEROUSLY override JSON prototype methods to handle uint64 values (bigint)
+// To avoid this we would have to write our own parser/serializer for the express
+// server.
+JSON.parse = JSONbig.parse;
+JSON.stringify = JSONbig.stringify;
 
 // Parse parameters that defines how to set up the server.
 const argv = minimist(process.argv.slice(2));

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -17,6 +17,11 @@ import {
     isValidBase64,
     isValidHash,
 } from './validation';
+import JSONbig from 'json-bigint';
+
+function parseJsonResponse(response: Uint8Array) {
+    return JSONbig.parse(JsonResponse.deserializeBinary(response).getValue());
+}
 
 class JsonRpcMethods {
     nodeClient: NodeClient;
@@ -50,10 +55,7 @@ class JsonRpcMethods {
                 accountAddressObject
             )
             .then((result) => {
-                return callback(
-                    null,
-                    JsonResponse.deserializeBinary(result).getValue()
-                );
+                return callback(null, parseJsonResponse(result));
             })
             .catch((e) => callback(e));
     }
@@ -83,10 +85,7 @@ class JsonRpcMethods {
                 transactionHashObject
             )
             .then((result) => {
-                return callback(
-                    null,
-                    JsonResponse.deserializeBinary(result).getValue()
-                );
+                return callback(null, parseJsonResponse(result));
             })
             .catch((e) => callback(e));
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,11 @@
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.6.tgz#674a69493ef2c849b95eafe69167ea59079eb504"
   integrity sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==
 
+"@types/json-bigint@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/json-bigint/-/json-bigint-1.0.1.tgz#201062a6990119a8cc18023cfe1fed12fc2fc8a7"
+  integrity sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==
+
 "@types/json-schema@^7.0.7":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
@@ -501,6 +506,11 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bignumber.js@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
+  integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
 
 body-parser@1.20.0:
   version "1.20.0"
@@ -1433,6 +1443,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## Purpose
We were returning stringified JSON objects instead of the JSON objects directly. This change fixes that so that actual JSON is returned as would be expected.

## Changes
- Return parsed JSON objects.
- Using json-bigint instead of the default JSON parse/stringifier to support bigint values which are required to handle uint64 values correctly. This is done with a prototype overwrite which is dangerous, but we avoid writing our own middleware by doing it like this.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.