### PR TITLE
Rename sendAccountTransaction to sendTransaction

### DIFF
--- a/doc/jsonrpc-api.md
+++ b/doc/jsonrpc-api.md
@@ -94,9 +94,9 @@ Response:
 }
 ```
 
-### sendAccountTransaction
+### sendTransaction
 
-Sends an account transaction to a node.
+Sends a transaction to a node.
 
 #### Parameters
 - `transaction` - base64 encoding of a signed account transaction
@@ -107,7 +107,7 @@ Request:
 {
     "jsonrpc": "2.0",
     "id": 1,
-    "method": "sendAccountTransaction",
+    "method": "sendTransaction",
     "params": {
         "transaction": "AAABAAEAAEDYMtcAlGVGIUE/VicCz7GtRPvTpwm4xicy6FSds0CpblXdVoOfxJbE2DHi/mNS1GK6gHSQYmICJRoPc2Lnz0oD8OdnyWx1BiXHSyOFGyzSZ9nl/dKY1cW1qRoJbng0DtgAAAAAAAAFfAAAAAAAAAH1AAAAKQAAAABie23oA7Tep/GZ0TjKmhwXBE78NRGgt/TpPUGOdcBiI5czrkzQAAAAAAAAAGQ="
     }

--- a/doc/jsonrpc-api.md
+++ b/doc/jsonrpc-api.md
@@ -99,7 +99,7 @@ Response:
 Sends a transaction to a node.
 
 #### Parameters
-- `transaction` - base64 encoding of a signed account transaction
+- `transaction` - base64 encoding of a signed transaction
 
 #### Example
 Request:

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -88,10 +88,7 @@ class JsonRpcMethods {
             .catch((e) => callback(e));
     }
 
-    sendTransaction(
-        transaction: string,
-        callback: JSONRPCCallbackTypePlain
-    ) {
+    sendTransaction(transaction: string, callback: JSONRPCCallbackTypePlain) {
         if (!isValidBase64(transaction)) {
             return invalidParameterError(
                 'The provided transaction [' +

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -88,7 +88,7 @@ class JsonRpcMethods {
             .catch((e) => callback(e));
     }
 
-    sendAccountTransaction(
+    sendTransaction(
         transaction: string,
         callback: JSONRPCCallbackTypePlain
     ) {
@@ -101,10 +101,10 @@ class JsonRpcMethods {
             );
         }
 
-        const serializedAccountTransaction = Buffer.from(transaction, 'base64');
+        const serializedTransaction = Buffer.from(transaction, 'base64');
         const sendTransactionRequest = new SendTransactionRequest();
         sendTransactionRequest.setNetworkId(100);
-        sendTransactionRequest.setPayload(serializedAccountTransaction);
+        sendTransactionRequest.setPayload(serializedTransaction);
 
         this.nodeClient
             .sendRequest(
@@ -331,12 +331,12 @@ export default function getJsonRpcMethods(nodeClient: NodeClient): {
                 params.transactionHash,
                 callback
             ),
-        sendAccountTransaction: (
+        sendTransaction: (
             params: { transaction: string },
             callback: JSONRPCCallbackTypePlain
         ) =>
             validateParams(params, ['transaction'], callback) &&
-            jsonRpcMethods.sendAccountTransaction(params.transaction, callback),
+            jsonRpcMethods.sendTransaction(params.transaction, callback),
         getInstanceInfo: (
             params: {
                 blockHash: string;

--- a/test/methods.test.ts
+++ b/test/methods.test.ts
@@ -96,14 +96,14 @@ test('get transaction status with invalid transaction hash fails', async () => {
     expect(response.body.error.message).toContain('is invalid');
 });
 
-test('send an account transaction with missing transaction fails', async () => {
-    const sendAccountTransactionWithInvalidTransaction = createRequest(
-        'sendAccountTransaction',
+test('send a transaction with missing transaction fails', async () => {
+    const sendTransactionWithInvalidTransaction = createRequest(
+        'sendTransaction',
         { someWrongParam: 'value!' }
     );
     const response = await request(app)
         .post('/')
-        .send(sendAccountTransactionWithInvalidTransaction);
+        .send(sendTransactionWithInvalidTransaction);
 
     expect(response.status).toBe(400);
     expect(response.body.error.code).toBe(-32602);
@@ -112,14 +112,14 @@ test('send an account transaction with missing transaction fails', async () => {
     );
 });
 
-test('send an account transaction with a wrong encoding fails', async () => {
-    const sendAccountTransactionWithInvalidTransaction = createRequest(
-        'sendAccountTransaction',
+test('send a transaction with a wrong encoding fails', async () => {
+    const sendTransactionWithInvalidTransaction = createRequest(
+        'sendTransaction',
         { transaction: 'ThisIsNotBase64Encoded!' }
     );
     const response = await request(app)
         .post('/')
-        .send(sendAccountTransactionWithInvalidTransaction);
+        .send(sendTransactionWithInvalidTransaction);
 
     expect(response.status).toBe(400);
     expect(response.body.error.code).toBe(-32602);


### PR DESCRIPTION
## Purpose

Rename sendAccountTransaction to sendTransaction, because it works with other types of transactions as well.

## Changes

Renamed sendAccountTransaction to sendTransaction and fixes related. naming/text 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.