### PR TITLE
Fix get module source response.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "concordium-json-rpc",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "A proxy server for forwarding JSON-RPC requests to the Concordium node",
     "repository": "git@github.com:Concordium/concordium-json-rpc.git",
     "author": {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -216,7 +216,9 @@ class JsonRpcMethods {
             )
             .then(({ result, metadata }) =>
                 callback(null, {
-                    result: Buffer.from(BytesResponse.deserializeBinary(result).getValue()).toString('base64'),
+                    result: Buffer.from(
+                        BytesResponse.deserializeBinary(result).getValue()
+                    ).toString('base64'),
                     metadata,
                 })
             )

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -5,6 +5,7 @@ import {
     BoolResponse,
     GetAddressInfoRequest,
     JsonResponse,
+    BytesResponse,
     SendTransactionRequest,
     TransactionHash,
     Empty,
@@ -215,7 +216,7 @@ class JsonRpcMethods {
             )
             .then(({ result, metadata }) =>
                 callback(null, {
-                    result: Buffer.from(result).toString('base64'),
+                    result: Buffer.from(BytesResponse.deserializeBinary(result).getValue()).toString('base64'),
                     metadata,
                 })
             )


### PR DESCRIPTION
## Purpose

The current encoding of the response includes the protobuf encoding of the length of the data. This is not how it should be, the fact "BytesResponse" is used internally is an implementation detail.

The change makes the response only include the actual data, not encoded with a length prefix.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
